### PR TITLE
Delete ManyToOne entities when nullable set to false

### DIFF
--- a/src/persistence/subject-builder/OneToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/OneToManySubjectBuilder.ts
@@ -165,12 +165,13 @@ export class OneToManySubjectBuilder {
                 const removedRelatedEntitySubject = new Subject({
                     metadata: relation.inverseEntityMetadata,
                     parentSubject: subject,
-                    canBeUpdated: true,
+                    canBeUpdated: relation.inverseRelation!.isNullable,
+                    mustBeRemoved: !relation.inverseRelation!.isNullable,
                     identifier: removedRelatedEntityRelationId,
-                    changeMaps: [{
+                    changeMaps: relation.inverseRelation!.isNullable ? [{
                         relation: relation.inverseRelation!,
                         value: null
-                    }]
+                    }] : undefined
                 });
                 this.subjects.push(removedRelatedEntitySubject);
             });


### PR DESCRIPTION
This update will delete `ManyToOne` entities when saved from the `OneToMany` side of the relationship if the option `nullable` is set to `false`.